### PR TITLE
Fixed import_gpio() and  gpio_setmode() issues

### DIFF
--- a/l293d/l293d.py
+++ b/l293d/l293d.py
@@ -17,30 +17,28 @@ def print_version():
 
 def import_gpio(): # RPi.GPIO module
     global test_mode
-    global pin_numbering
     try:
         import RPi.GPIO as GPIO
-        if pin_numbering == 'BOARD':
-            GPIO.setmode(GPIO.BOARD)
-            if verbose: print('GPIO mode set (GPIO.BOARD)')
-        else:
-            GPIO.setmode(GPIO.BCM)
-            if verbose: print('GPIO mode set (GPIO.BCM)')
+	global GPIO
         GPIO.setwarnings(False)
     except Exception as e:
         print("Can't import RPi.GPIO. Please (re)install.")
         test_mode = True
         print('Test mode has been enabled. Please view README for more info.')
 
-def gpio_setmode(): #Sets BOARD
+def gpio_setmode(): #Sets GPIO numbering scheme
     global test_mode
+    global pin_numbering
     if not test_mode:
         try:
-            GPIO.setmode(GPIO.BOARD)
-            GPIO.setwarnings(False)
-            if verbose: print('GPIO mode set (GPIO.BOARD)')
+            if pin_numbering == 'BOARD':
+                GPIO.setmode(GPIO.BOARD)
+                if verbose: print('GPIO mode set (GPIO.BOARD)')
+            else:
+                GPIO.setmode(GPIO.BCM)
+                if verbose: print('GPIO mode set (GPIO.BCM)')
         except Exception as e:
-            print('Can\'t set GPIO mode (GPIO.BOARD)')
+            print('Can\'t set GPIO mode')
 
 from time import sleep
 from threading import Thread
@@ -74,9 +72,9 @@ class motor(object):
     def pins_are_valid(self, pins, force_selection=False):
         global pin_numbering
         if pin_numbering == 'BOARD':
-            valid_pins = [4, 17, 18, 27, 22, 23, 24, 25, 5, 6, 12, 13, 16, 26]
-        else: 
             valid_pins = [7, 11, 12, 13, 15, 16, 18, 22, 29, 31, 32, 33, 36, 37]
+        else: # 'BCM'
+            valid_pins = [4, 5, 6, 12, 13, 16, 17, 18, 22, 23, 24, 25, 26, 27]
         for pin in pins:
             pin_int = int(pin)
             if (pin_int not in valid_pins) and (force_selection is not True):


### PR DESCRIPTION
Found some issues while running tests: 

-GPIO setmode called in wrong function
-Exception raised during gpio_setmode(), global name GPIO not recognized

First one was my oversight - I hadn't noticed that there was a setup function that set the GPIO mode so my code in #5 was no good. Moved the GPIO.setmode() functions from import_gpio() to gpio_setmodet(), and it works as designed now. 

Second issue was due to importing RPi.GPIO in a function locally rather than globally, and the name GPIO was not declared as global. Added global declaration in import_gpio().



