### PR TITLE
Added [l293d] to output

### DIFF
--- a/l293d/driver.py
+++ b/l293d/driver.py
@@ -15,7 +15,7 @@ def v_print(string):
     :return: True if printed, otherwise False
     """
     if Config.get_verbose():
-        print(str(string))
+        print("[l293d]: {0}".format(str(string)))
         return True
     return False
 


### PR DESCRIPTION
In this pr I have made an initial change to the v_print function.

There's also the question of whether you want the other calls to print changing ([here](https://github.com/jamesevickery/l293d/blob/master/l293d/driver.py#L64) and [here](https://github.com/jamesevickery/l293d/blob/master/l293d/driver.py#L80), amongst others)?

I don't mind modifying the code to use the logging module but it does require some slight refactoring and since you are the owner you can make that call.

I'd highly recommend using the [logging](https://docs.python.org/2/library/logging.html) module since this was exactly the kind of thing it was created for. It will need clients to setup the logger first instead of calling your `config.set_verbose()` function but I would hope they are doing that anyway...

Let me know your thoughts...

