### PR TITLE
Add properties

### DIFF
--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -6,7 +6,7 @@ Test mode (`test_mode`) is a paramter of the l293d config. By default it's off (
 
 ![l293d-import-test-mode](http://i.imgur.com/6aZnUiv.png?1)
 
-_To change the value of `test_mode`, use `l293d.Config.set_test_mode(value)`, where value is True or False._
+_To change the value of `test_mode`, use `l293d.Config.test_mode = value`, where value is True or False._
 
 ## Verbosity
 
@@ -14,13 +14,13 @@ Verbosity (`verbose`) is another True/False config value. l293d only prints text
 
 The only thing that you should see as output from l293d when `verbose` is `False`, is when an exception is raised.
 
-_To change the value of `verbose`, use `l293d.Config.set_verbose(value)`, where value is True or False._
+_To change the value of `verbose`, use `l293d.Config.verbose = value`, where value is True or False._
 
 
 ## Pin Numbering
 
 Pin numbering (`pin_numbering`) is either BOARD or BCM. These are different ways of numbering the Raspberry Pi's pins. BOARD numbering refers to the physical location of the pins, whereas BCM refers to the Broadcom pin number. A good pinout diagram labelling the pin & BCM numbers can be found at [pinout.xyz](https://pinout.xyz/).
 
-_To change the value of `pin_numbering`, use `l293d.Config.set_pin_numbering(value)`, where value is either 'BOARD' or 'BCM'._
+_To change the value of `pin_numbering`, use `l293d.Config.pin_numbering = value`, where value is either 'BOARD' or 'BCM'._
 
 This value should only be changed before any motors have been defined. If you try to call `l293d.Config.set_pin_numbering` after defining a motor, an exception (`ValueError`) is raised.

--- a/l293d/driver.py
+++ b/l293d/driver.py
@@ -14,40 +14,87 @@ def v_print(string):
     :param string: Text to print if verbose
     :return: True if printed, otherwise False
     """
-    if Config.get_verbose():
+    if Config.verbose:
         print(str(string))
         return True
     return False
 
 
+class ConfigMeta(type):
+    def __call__(cls):
+        """
+        Stops the creation of Config objects.
+        """
+        raise EnvironmentError(
+            "Cannot create an intance of '{0}', use {0}.attr instead.".format(
+                cls.__name__))
+
+    def __getattr__(cls, attr):
+        """
+        Try and call get_`attr` on the cls.
+        """
+        try:
+            return cls.__dict__["get_" + attr]()
+        except KeyError:
+            raise AttributeError(
+                "object '{}' has no attribute '{}'".format(
+                    cls.__name__, attr))
+
+    def __setattr__(cls, attr, value):
+        """
+        Try and call set_`attr` on the cls.
+        """
+        if cls.__name__ not in attr:
+            # First try calling the set_ method. This will allow the set_
+            # method to perform it's checks, then recursively call this method.
+            try:
+                cls.__dict__["set_" + attr](value)
+            except KeyError:
+                raise AttributeError(
+                    "object '{}' has no attribute '{}'".format(
+                        cls.__name__, attr))
+        else:
+            # Now that the set_ method has done it's checks, we can use super()
+            # to actually set the value.
+            super(ConfigMeta, cls).__setattr__(attr, value)
+
+
+def with_metaclass(mcls):
+    """
+    Allows compatibility for metaclass in python2 and python3
+    """
+    def decorator(cls):
+        body = vars(cls).copy()
+        body.pop("__dict__", None)
+        body.pop("__weakref__", None)
+        return mcls(cls.__name__, cls.__bases__, body)
+    return decorator
+
+
+@with_metaclass(ConfigMeta)
 class Config(object):
     __verbose = True
     __test_mode = False
     __pin_numbering = 'BOARD'
 
-    @staticmethod
     def set_verbose(value):
         if type(value) == bool:
             Config.__verbose = value
         else:
             raise TypeError('verbose must be either True or False')
 
-    @staticmethod
     def get_verbose():
         return Config.__verbose
 
-    @staticmethod
     def set_test_mode(value):
         if type(value) == bool:
             Config.__test_mode = value
         else:
             raise TypeError('test_mode must be either True or False')
 
-    @staticmethod
     def get_test_mode():
         return Config.__test_mode
 
-    @staticmethod
     def set_pin_numbering(value):
         if type(value) != str:
             raise TypeError('pin_numbering must be a string:'
@@ -64,7 +111,6 @@ class Config(object):
         print("Pin numbering format set: " + value)
         return value
 
-    @staticmethod
     def get_pin_numbering():
         return Config.__pin_numbering
 
@@ -78,18 +124,18 @@ try:
 except ImportError:
     GPIO = None
     print("Can't import RPi.GPIO. Please (re)install.")
-    Config.set_test_mode(True)
+    Config.test_mode = True
     print('Test mode has been enabled. Please view README for more info.')
 
-if not Config.get_test_mode():
+if not Config.test_mode:
     GPIO.setwarnings(False)
 
 # Set GPIO mode
-if not Config.get_test_mode():
-    if Config.get_pin_numbering() == 'BOARD':
+if not Config.test_mode:
+    if Config.pin_numbering == 'BOARD':
         v_print('Setting GPIO mode: BOARD')
         GPIO.setmode(GPIO.BOARD)
-    elif Config.get_pin_numbering() == 'BCM':
+    elif Config.pin_numbering == 'BCM':
         v_print('Setting GPIO mode: BCM')
         GPIO.setmode(GPIO.BCM)
     else:
@@ -114,7 +160,7 @@ class DC(object):
         self.motor_pins[1] = pin_b
         self.motor_pins[2] = pin_c
 
-        self.pin_numbering = Config.get_pin_numbering()
+        self.pin_numbering = Config.pin_numbering
 
         self.reversed = False
 
@@ -132,7 +178,7 @@ class DC(object):
         Set GPIO.OUT for each pin in use
         """
         for pin in self.motor_pins:
-            if not Config.get_test_mode():
+            if not Config.test_mode:
                 GPIO.setup(pin, GPIO.OUT)
 
     def drive_motor(self, direction=1, duration=None, wait=True):
@@ -142,7 +188,7 @@ class DC(object):
         self.check()
         if self.reversed:
             direction *= -1
-        if not Config.get_test_mode():
+        if not Config.test_mode:
             if direction == 0:  # Then stop motor
                 GPIO.output(self.motor_pins[0], GPIO.LOW)
             else:  # Spin motor
@@ -172,7 +218,7 @@ class DC(object):
         Uses drive_motor to spin the motor in `direction`
         """
         self.check()
-        if Config.get_verbose():
+        if Config.verbose:
             v_print('{action} {reversed}motor at '
                     '{pin_nums} pins {pin_str}'.format(
                         action=action,
@@ -244,11 +290,11 @@ def pins_are_valid(pins, force_selection=False):
     """
     # Pin numbering, used below, should be
     # a parameter of this function (future)
-    if Config.get_pin_numbering() == 'BOARD':  # Set valid pins for BOARD
+    if Config.pin_numbering == 'BOARD':  # Set valid pins for BOARD
         valid_pins = [
             7, 11, 12, 13, 15, 16, 18, 22, 29, 31, 32, 33, 36, 37
         ]
-    elif Config.get_pin_numbering() == 'BCM':  # Set valid pins for BCM
+    elif Config.pin_numbering == 'BCM':  # Set valid pins for BCM
         valid_pins = [
             4, 5, 6, 12, 13, 16, 17, 18, 22, 23, 24, 25, 26, 27
         ]
@@ -271,7 +317,7 @@ def cleanup():
     """
     Call GPIO cleanup method
     """
-    if not Config.get_test_mode():
+    if not Config.test_mode:
         try:
             GPIO.cleanup()
             v_print('GPIO cleanup successful.')

--- a/l293d/driver.py
+++ b/l293d/driver.py
@@ -34,7 +34,7 @@ class ConfigMeta(type):
         Try and call get_`attr` on the cls.
         """
         try:
-            return cls.__dict__["get_" + attr]()
+            return cls.__dict__["get_" + attr].__func__(cls)
         except KeyError:
             raise AttributeError(
                 "object '{}' has no attribute '{}'".format(
@@ -48,7 +48,7 @@ class ConfigMeta(type):
             # First try calling the set_ method. This will allow the set_
             # method to perform it's checks, then recursively call this method.
             try:
-                cls.__dict__["set_" + attr](value)
+                cls.__dict__["set_" + attr].__func__(cls, value)
             except KeyError:
                 raise AttributeError(
                     "object '{}' has no attribute '{}'".format(
@@ -77,25 +77,30 @@ class Config(object):
     __test_mode = False
     __pin_numbering = 'BOARD'
 
-    def set_verbose(value):
+    @classmethod
+    def set_verbose(cls, value):
         if type(value) == bool:
             Config.__verbose = value
         else:
             raise TypeError('verbose must be either True or False')
 
-    def get_verbose():
+    @classmethod
+    def get_verbose(cls):
         return Config.__verbose
 
-    def set_test_mode(value):
+    @classmethod
+    def set_test_mode(cls, value):
         if type(value) == bool:
             Config.__test_mode = value
         else:
             raise TypeError('test_mode must be either True or False')
 
-    def get_test_mode():
+    @classmethod
+    def get_test_mode(cls):
         return Config.__test_mode
 
-    def set_pin_numbering(value):
+    @classmethod
+    def set_pin_numbering(cls, value):
         if type(value) != str:
             raise TypeError('pin_numbering must be a string:'
                             '\'BOARD\' or \'BCM\'')
@@ -111,7 +116,8 @@ class Config(object):
         print("Pin numbering format set: " + value)
         return value
 
-    def get_pin_numbering():
+    @classmethod
+    def get_pin_numbering(cls):
         return Config.__pin_numbering
 
 

--- a/tests/test_l293d.py
+++ b/tests/test_l293d.py
@@ -86,7 +86,6 @@ class L293DTestCase(unittest.TestCase):
         m1.remove()
         reload(d.driver)
 
-
     def test_getting_config(self):
         """
         Test that Config supports both get_ and properties
@@ -94,7 +93,6 @@ class L293DTestCase(unittest.TestCase):
         import l293d as d
 
         self.assertEqual(d.Config.pin_numbering, d.Config.get_pin_numbering())
-
 
     def test_setting_config(self):
         """
@@ -109,8 +107,6 @@ class L293DTestCase(unittest.TestCase):
 
         d.Config.verbose = False
         self.assertEqual(d.Config.verbose, d.Config.get_verbose())
-
-
 
 
 if __name__ == '__main__':

--- a/tests/test_l293d.py
+++ b/tests/test_l293d.py
@@ -68,15 +68,15 @@ class L293DTestCase(unittest.TestCase):
         reload(d.driver)
 
     def test_pin_numbering_lock(self):
-        """"
+        """
         Test that pin_numbering can't be changed after a motor's definition
         """
         import l293d as d
-        d.Config.set_pin_numbering('BcM')
+        d.Config.pin_numbering = 'BcM'
         m1 = d.DC(4, 5, 6)
         error = 'No error'
         try:
-            d.Config.set_pin_numbering('BoaRD')
+            d.Config.pin_numbering = 'BoaRD'
         except ValueError as e:
             error = str(e)
         self.assertEqual(
@@ -85,6 +85,32 @@ class L293DTestCase(unittest.TestCase):
                    'the start of your script.')
         m1.remove()
         reload(d.driver)
+
+
+    def test_getting_config(self):
+        """
+        Test that Config supports both get_ and properties
+        """
+        import l293d as d
+
+        self.assertEqual(d.Config.pin_numbering, d.Config.get_pin_numbering())
+
+
+    def test_setting_config(self):
+        """
+        Test that Config supports both set_ and properties
+        """
+        import l293d as d
+
+        d.Config.set_verbose(False)
+        self.assertEqual(d.Config.verbose, d.Config.get_verbose())
+
+        reload(d.driver)
+
+        d.Config.verbose = False
+        self.assertEqual(d.Config.verbose, d.Config.get_verbose())
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This addresses #65.

It isn't as clean as a pure `@property` approach, but it turns out you can't use `@property` and `@staticmethod` at the same time. So to keep the `Config` functioning as a namespace like it is now (instead of requiring Config to be created as an object), I had to add the property functionallity to a MetaClass.